### PR TITLE
share: remove site baseurl

### DIFF
--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -1,4 +1,4 @@
-<a class="twitter" href="https://twitter.com/intent/tweet?text={{ .Site.BaseURL }}{{ .Permalink }} - {{ .Title }} {{ with .Site.Params.twitter }}by @{{ . }}{{ end }}"><span class="icon-twitter"> {{ with .Site.Params.tweet }}{{ . }}{{ else }}Tweet{{ end }}</span></a>
+<a class="twitter" href="https://twitter.com/intent/tweet?text={{ .Permalink }} - {{ .Title }} {{ with .Site.Params.twitter }}by @{{ . }}{{ end }}"><span class="icon-twitter"> {{ with .Site.Params.tweet }}{{ . }}{{ else }}Tweet{{ end }}</span></a>
 
 <a class="facebook" href="#" onclick="
     window.open(


### PR DESCRIPTION
`{{.Permalink}}` has the base URL in the permalink already. I just removed the `{{.Site.BaseURL}}`, but `{{.Site.BaseURL}}{{.RelPermalink}}` could work too.
