### PR TITLE
Way to disable highlight.js

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,11 @@
 <title>{{ .Title }}{{ if .IsHome }} &middot; {{ .Site.Title }}{{ end }}</title>
 <link rel="shortcut icon" href="{{ "images/favicon.ico" | absURL }}">
 <link rel="stylesheet" href="{{ "css/style.css" | absURL }}">
+
+{{ if .Site.Params.disableHighlight }}
+{{ else }}
 <link rel="stylesheet" href="{{ "css/highlight.css" | absURL }}">
+{{ end }}
 {{ range .Site.Params.customCSS }}
 <link rel="stylesheet" href="{{ . | absURL }}">
 {{ end }}

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -1,7 +1,10 @@
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="{{ "js/main.js" | absURL }}"></script>
+{{ if .Site.Params.disableHighlight }}
+{{ else }}
 <script src="{{ "js/highlight.js" | absURL }}"></script>
 <script>hljs.initHighlightingOnLoad();</script>
+{{ end }}
 
 {{ range .Site.Params.customJS }}
 <script src="{{ . | absURL }}"></script>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -661,7 +661,7 @@ a.symbol:hover {
     color: #BCD4DA;
 }
 
-code { 
+p code { 
 	font-family:Menlo, Monaco, Courier; 
 	background-color:#EEE; font-size:14px; 
 	padding: 4px; 


### PR DESCRIPTION
As I had the issue myself, I wanted to fix #33

It's working without breaking changes as you have to manually disable highlight.js.

A downside right now is that highlight.js is still copied into /public, but it won't be loaded by the client.

When disabling highlight.js, I noticed that style.css was messing up the code views as well. I also fixed that by only applying the code style in paragraphs.

Copied from #45, as I used the wrong 'compare'.