### PR TITLE
Fix left margin for nested UL/OL inside LI tag

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -184,6 +184,7 @@ ul, ol 	{ margin:0; padding:0; margin-bottom: 20px; }
 ul { list-style-type:circle; }
 ol { list-style: decimal; }
 li	{  list-style-position:inside; }
+li ol, li ul { margin-left: 20px; }
 
 /* Line Height */
 #post-body, p { line-height:1.7; }


### PR DESCRIPTION
When you have a list inside a `li` tag it appears in the same level as the parent as follows:
![screenshot-2018-02-11_19-55-04](https://user-images.githubusercontent.com/54403/36077063-223d114e-0f66-11e8-95bf-8a0db9f903de.png)

That fix will add a margin for it from the left side:
![screenshot-2018-02-11_19-56-32](https://user-images.githubusercontent.com/54403/36077065-337065ec-0f66-11e8-80e3-f6cfdca46845.png)
