### PR TITLE
Fix default code text background

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -661,9 +661,9 @@ a.symbol:hover {
     color: #BCD4DA;
 }
 
-code { 
-	font-family:Menlo, Monaco, Courier; 
-	background-color:#EEE; font-size:14px; 
-	padding: 4px; 
+code {
+	font-family:Menlo, Monaco, Courier;
+	font-size:14px;
+	padding: 4px;
 	font-weight: 600;
 }


### PR DESCRIPTION
If you're you're code block language is not supported the text background stays `#eee` as specified in the stylesheet, which makes it appear as follows:
![screenshot-2018-02-11_20-00-44](https://user-images.githubusercontent.com/54403/36077145-1f0fb7dc-0f67-11e8-8467-1e6c76fa7f47.png)

but even if the block language isn't supported it should appear without a background color as follows:
![screenshot-2018-02-11_20-01-27](https://user-images.githubusercontent.com/54403/36077165-60b4027e-0f67-11e8-8ec2-d79ef28ef183.png)
