### PR TITLE
Make easier to develop with ngrok

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,7 +9,7 @@
         {{ with .Params.tags }}
         {{ if ge (len .) 1 }}
             {{ range . }}
-                <a href="{{ printf "tags/%s" (. | urlize) | absURL }}">{{ . }}</a>
+                <a href="{{ printf "tags/%s" (. | urlize) | relURL }}">{{ . }}</a>
             {{ end }}
         {{ end }}
         {{ end}}
@@ -22,7 +22,7 @@
 
 <footer id="post-meta" class="clearfix">
     {{ with .Site.Params.twitter }}<a href="https://twitter.com/{{ . }}">{{ end }}
-    <img class="avatar" src="{{ "images/avatar.png" | absURL }}">
+    <img class="avatar" src="{{ "images/avatar.png" | relURL }}">
     <div>
         <span class="dark">{{ .Site.Params.name }}</span>
         <span>{{ .Site.Params.aboutAuthor }}</span>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,17 +5,17 @@
 {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
 {{ .Hugo.Generator }}
 <title>{{ .Title }}{{ if .IsHome }} &middot; {{ .Site.Title }}{{ end }}</title>
-<link rel="shortcut icon" href="{{ "images/favicon.ico" | absURL }}">
-<link rel="stylesheet" href="{{ "css/style.css" | absURL }}">
-<link rel="stylesheet" href="{{ "css/highlight.css" | absURL }}">
+<link rel="shortcut icon" href="{{ "images/favicon.ico" | relURL }}">
+<link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+<link rel="stylesheet" href="{{ "css/highlight.css" | relURL }}">
 {{ range .Site.Params.customCSS }}
-<link rel="stylesheet" href="{{ . | absURL }}">
+<link rel="stylesheet" href="{{ . | relURL }}">
 {{ end }}
 
 {{ if eq .Site.Params.iconFont "font-awesome" }}
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css">
 {{ else }}
-<link rel="stylesheet" href="{{ "css/monosocialiconsfont.css" | absURL }}">
+<link rel="stylesheet" href="{{ "css/monosocialiconsfont.css" | relURL }}">
 {{ end }}
 
 {{ if .Site.Params.enableRSS }}

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -1,10 +1,10 @@
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-<script src="{{ "js/main.js" | absURL }}"></script>
-<script src="{{ "js/highlight.js" | absURL }}"></script>
+<script src="{{ "js/main.js" | relURL }}"></script>
+<script src="{{ "js/highlight.js" | relURL }}"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 
 {{ range .Site.Params.customJS }}
-<script src="{{ . | absURL }}"></script>
+<script src="{{ . | relURL }}"></script>
 {{ end }}
 
 {{ template "_internal/google_analytics.html" . }}

--- a/layouts/partials/profile.html
+++ b/layouts/partials/profile.html
@@ -1,8 +1,8 @@
 <div class="profile">
     <section id="wrapper">
         <header id="header">
-            <a href="{{ "about" | absURL }}">
-                <img id="avatar" class="2x" src="{{ "images/avatar.png" | absURL }}"/>
+            <a href="{{ "about" | relURL }}">
+                <img id="avatar" class="2x" src="{{ "images/avatar.png" | relURL }}"/>
             </a>
             <h1>{{ .Site.Params.name }}</h1>
             <h2>{{ .Site.Params.bio | markdownify }}</h2>


### PR DESCRIPTION
What
===
Replace uses of `absURL` with `relURL`.

Why
===
`absURL` inserts an absolute URL in the form of `http://localhost:1313/path/to/style.css` which makes it impossible to develop on a non-localhost hostname. For example if I'm using `ngrok` to serve my localhost to a domain like `https://8863fbca4.grok.io/` resources linked with `absURL` will still incorrectly reference `localhost`. Using `relURL` removes the hostname from the links. Relative links generally make it easier to work with a website during development.