### PR TITLE
Fix hugo 0.55 warnings

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {{ with .Site.Params.name }}<meta name="author" content="{{ . }}">{{ end }}
 {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 <title>{{ .Title }}{{ if .IsHome }} &middot; {{ .Site.Title }}{{ end }}</title>
 <link rel="shortcut icon" href="{{ "images/favicon.ico" | absURL }}">
 <link rel="stylesheet" href="{{ "css/style.css" | absURL }}">

--- a/layouts/partials/latest-posts.html
+++ b/layouts/partials/latest-posts.html
@@ -2,10 +2,10 @@
     <h3>{{ .Site.Params.readMore | default "Read more" }}</h3>
 
     {{ $kind := where .Site.RegularPages "Section" "!=" "" }}
-    {{ $othr := where $kind "URL" "!=" .URL }}
+    {{ $othr := where $kind "Permalink" "!=" .Permalink }}
     {{ range first 10 $othr }}
         <li>
-            <a href="{{ .URL }}">{{ .LinkTitle }}<aside class="dates">{{ .Date.Format "Jan 2 2006" }}</aside></a>
+            <a href="{{ .Permalink }}">{{ .LinkTitle }}<aside class="dates">{{ .Date.Format "Jan 2 2006" }}</aside></a>
         </li>
     {{ end }}
 </ul>

--- a/layouts/partials/post-list.html
+++ b/layouts/partials/post-list.html
@@ -1,8 +1,8 @@
 <ul id="post-list">
     {{ range where .Paginator.Pages "Section" "ne" "" }}
         <li>
-            <a href='{{ .URL }}'><aside class="dates">{{ .Date.Format "Jan 2 2006" }}</aside></a>
-            <a href='{{ .URL }}'>{{ .LinkTitle }}<h2>{{ .Description | markdownify }}</h2></a>
+            <a href='{{ .Permalink }}'><aside class="dates">{{ .Date.Format "Jan 2 2006" }}</aside></a>
+            <a href='{{ .Permalink }}'>{{ .LinkTitle }}<h2>{{ .Description | markdownify }}</h2></a>
         </li>
     {{ end }}
 </ul>


### PR DESCRIPTION
To get rid of the: 

```
Building sites … WARN 2019/07/07 12:48:13 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
WARN 2019/07/07 12:48:13 Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url.
```